### PR TITLE
Add support for a local filesystem backed storage engine

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
+resolver = "2"
 members = [
 	"chroma",
 	"proto",
 	"dal",
 ]
 
-[patch.crates-io]
-libc = { git = 'https://github.com/rust-lang/libc.git', rev = "e71a4c0b1fd40050f50844e2a752576bcb6b5edb" }
+#[patch.crates-io]
+#libc = { git = 'https://github.com/rust-lang/libc.git', rev = "e71a4c0b1fd40050f50844e2a752576bcb6b5edb" }

--- a/server/chroma/Cargo.toml
+++ b/server/chroma/Cargo.toml
@@ -13,7 +13,7 @@ proto = { version = "0.1.0", path = "../proto" }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.38"
 tracing = "0.1.37"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.29.1", features = ["full"] }
 tracing-actix-web = "0.7.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 dal = { version = "0.1.0", path = "../dal" }

--- a/server/chroma/src/routes/appdata.rs
+++ b/server/chroma/src/routes/appdata.rs
@@ -1,13 +1,13 @@
 use crate::config::Config;
 use actix_web::web;
 use dal::database::Database;
-use dal::s3::S3;
+use dal::storage_engine::StorageEngine;
 
 pub type WebData = web::Data<AppData>;
 
 #[derive(Debug, Clone)]
 pub struct AppData {
     pub db: Database,
-    pub s3: S3,
+    pub storage: StorageEngine,
     pub config: Config,
 }

--- a/server/chroma/src/routes/error.rs
+++ b/server/chroma/src/routes/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("Bad request: {0}")]
     BadRequest(String),
     #[error("Internal server error")]
-    S3(#[from] dal::s3::S3Error),
+    StorageEngine(#[from] dal::storage_engine::StorageEngineError),
     #[error("Something went wrong on Koala's end")]
     Koala(reqwest::Error),
     #[error("The requested resource may not be accessed by the authorized user.")]
@@ -30,7 +30,7 @@ impl ResponseError for Error {
             Self::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
-            Self::S3(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::StorageEngine(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Koala(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::ChronoParse(_) => StatusCode::BAD_GATEWAY,

--- a/server/chroma/src/routes/v1/album/get.rs
+++ b/server/chroma/src/routes/v1/album/get.rs
@@ -4,10 +4,11 @@ use crate::routes::error::{Error, WebResult};
 use actix_multiresponse::Payload;
 use actix_web::web;
 use dal::database::{Album, Photo};
-use dal::s3::{PhotoQuality, S3Error};
+use dal::storage_engine::StorageEngineError;
 use futures::future::join_all;
 use proto::GetAlbumResponse;
 use serde::Deserialize;
+use dal::storage_engine::PhotoQuality;
 
 #[derive(Debug, Deserialize)]
 pub struct Query {
@@ -34,11 +35,11 @@ pub async fn get(
     let photos = join_all(
         photos
             .into_iter()
-            .map(|photo| photo.photo_to_proto(&data.s3, PhotoQuality::Original)),
+            .map(|photo| photo.photo_to_proto(&data.storage, PhotoQuality::Original)),
     )
     .await
     .into_iter()
-    .collect::<Result<Vec<_>, S3Error>>()?;
+    .collect::<Result<Vec<_>, StorageEngineError>>()?;
 
     Ok(Payload(GetAlbumResponse {
         photos,

--- a/server/chroma/src/routes/v1/album/get.rs
+++ b/server/chroma/src/routes/v1/album/get.rs
@@ -4,11 +4,11 @@ use crate::routes::error::{Error, WebResult};
 use actix_multiresponse::Payload;
 use actix_web::web;
 use dal::database::{Album, Photo};
+use dal::storage_engine::PhotoQuality;
 use dal::storage_engine::StorageEngineError;
 use futures::future::join_all;
 use proto::GetAlbumResponse;
 use serde::Deserialize;
-use dal::storage_engine::PhotoQuality;
 
 #[derive(Debug, Deserialize)]
 pub struct Query {

--- a/server/chroma/src/routes/v1/photo/create.rs
+++ b/server/chroma/src/routes/v1/photo/create.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use image::codecs::png::PngDecoder;
 use image::imageops::FilterType;
 use tracing::{info, warn};
-use dal::s3::PhotoQuality;
+use dal::storage_engine::PhotoQuality;
 
 /// Create a new photo in an existing album.
 ///
@@ -62,7 +62,7 @@ pub async fn create(
 
     // Upload the photo to S3
     // If this fails, remove the metadata again
-    if let Err(e) = data.s3.create_photo(&photo.id, png_image.clone(), PhotoQuality::Original).await {
+    if let Err(e) = data.storage.create_photo(&photo.id, png_image.clone(), PhotoQuality::Original).await {
         photo.delete().await?;
         return Err(e.into());
     }
@@ -92,7 +92,7 @@ pub async fn create(
         };
 
         match convert_quality(&img, 400) {
-            Ok(w400) => match data.s3.create_photo(&id, w400, PhotoQuality::W400).await {
+            Ok(w400) => match data.storage.create_photo(&id, w400, PhotoQuality::W400).await {
                 Ok(_) => {},
                 Err(e) => warn!("Failed to upload W400 photo: {e}"),
             },
@@ -100,7 +100,7 @@ pub async fn create(
         }
 
         match convert_quality(&img, 1600) {
-            Ok(w1600) => match data.s3.create_photo(&id, w1600, PhotoQuality::W1600).await {
+            Ok(w1600) => match data.storage.create_photo(&id, w1600, PhotoQuality::W1600).await {
                 Ok(_) => {},
                 Err(e) => warn!("Failed to upload W1600 photo: {e}"),
             },

--- a/server/chroma/src/routes/v1/photo/delete.rs
+++ b/server/chroma/src/routes/v1/photo/delete.rs
@@ -4,6 +4,7 @@ use crate::routes::empty::Empty;
 use crate::routes::error::{Error, WebResult};
 use actix_multiresponse::Payload;
 use dal::database::Photo;
+use dal::storage_engine::PhotoQuality;
 use proto::DeletePhotoRequest;
 
 /// Delete a photo.
@@ -29,7 +30,9 @@ pub async fn delete(
     let id = photo.id.clone();
     photo.delete().await?;
 
-    data.s3.delete_photo(id).await?;
+    data.storage.delete_photo(&id, PhotoQuality::Original).await?;
+    data.storage.delete_photo(&id, PhotoQuality::W1600).await?;
+    data.storage.delete_photo(&id, PhotoQuality::W400).await?;
 
     Ok(Empty)
 }

--- a/server/chroma/src/routes/v1/photo/delete.rs
+++ b/server/chroma/src/routes/v1/photo/delete.rs
@@ -30,7 +30,9 @@ pub async fn delete(
     let id = photo.id.clone();
     photo.delete().await?;
 
-    data.storage.delete_photo(&id, PhotoQuality::Original).await?;
+    data.storage
+        .delete_photo(&id, PhotoQuality::Original)
+        .await?;
     data.storage.delete_photo(&id, PhotoQuality::W1600).await?;
     data.storage.delete_photo(&id, PhotoQuality::W400).await?;
 

--- a/server/chroma/src/routes/v1/photo/get.rs
+++ b/server/chroma/src/routes/v1/photo/get.rs
@@ -6,7 +6,7 @@ use actix_web::web;
 use dal::database::Photo;
 use proto::GetPhotoResponse;
 use serde::Deserialize;
-use dal::s3::PhotoQuality;
+use dal::storage_engine::PhotoQuality;
 
 #[derive(Debug, Deserialize)]
 pub struct Query {
@@ -30,6 +30,6 @@ pub async fn get(
         .ok_or(Error::NotFound)?;
 
     Ok(Payload(GetPhotoResponse {
-        photo: Some(photo.photo_to_proto(&data.s3, PhotoQuality::Original).await?),
+        photo: Some(photo.photo_to_proto(&data.storage, PhotoQuality::Original).await?),
     }))
 }

--- a/server/chroma/src/routes/v1/photo/get.rs
+++ b/server/chroma/src/routes/v1/photo/get.rs
@@ -4,9 +4,9 @@ use crate::routes::error::{Error, WebResult};
 use actix_multiresponse::Payload;
 use actix_web::web;
 use dal::database::Photo;
+use dal::storage_engine::PhotoQuality;
 use proto::GetPhotoResponse;
 use serde::Deserialize;
-use dal::storage_engine::PhotoQuality;
 
 #[derive(Debug, Deserialize)]
 pub struct Query {
@@ -30,6 +30,10 @@ pub async fn get(
         .ok_or(Error::NotFound)?;
 
     Ok(Payload(GetPhotoResponse {
-        photo: Some(photo.photo_to_proto(&data.storage, PhotoQuality::Original).await?),
+        photo: Some(
+            photo
+                .photo_to_proto(&data.storage, PhotoQuality::Original)
+                .await?,
+        ),
     }))
 }

--- a/server/chroma/src/routes/v1/photo/list.rs
+++ b/server/chroma/src/routes/v1/photo/list.rs
@@ -14,7 +14,7 @@ pub struct Query {
     /// The ID of the album to list all photos from
     album_id: Option<String>,
     #[serde(default)]
-    quality_preference: Quality
+    quality_preference: Quality,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/server/chroma/src/routes/v1/photo/list.rs
+++ b/server/chroma/src/routes/v1/photo/list.rs
@@ -4,7 +4,7 @@ use crate::routes::error::WebResult;
 use actix_multiresponse::Payload;
 use actix_web::web;
 use dal::database::Photo;
-use dal::s3::{PhotoQuality, S3Error};
+use dal::storage_engine::{PhotoQuality, StorageEngineError};
 use futures::future::join_all;
 use proto::ListPhotoResponse;
 use serde::Deserialize;
@@ -53,10 +53,10 @@ pub async fn list(
         photos: join_all(
             photos
                 .into_iter()
-                .map(|photo| photo.photo_to_proto(&data.s3, quality_preference.clone())),
+                .map(|photo| photo.photo_to_proto(&data.storage, quality_preference.clone())),
         )
         .await
         .into_iter()
-        .collect::<Result<Vec<_>, S3Error>>()?,
+        .collect::<Result<Vec<_>, StorageEngineError>>()?,
     }))
 }

--- a/server/dal/Cargo.toml
+++ b/server/dal/Cargo.toml
@@ -18,3 +18,4 @@ tracing = "0.1.37"
 strum = "0.24.1"
 strum_macros = "0.24.3"
 async-recursion = "1.0.4"
+tokio = { version = "1.29.1", features = ["io-std", "fs"] }

--- a/server/dal/src/database/photo.rs
+++ b/server/dal/src/database/photo.rs
@@ -1,5 +1,5 @@
 use crate::database::{Album, Database, DbResult};
-use crate::s3::{S3Error, S3, PhotoQuality};
+use crate::storage_engine::{PhotoQuality, StorageEngine, StorageEngineError};
 use rand::Rng;
 use sqlx::FromRow;
 use time::OffsetDateTime;
@@ -38,9 +38,13 @@ impl<'a> Photo<'a> {
     ///
     /// # Errors
     ///
-    /// If fetching the photo's contents from S3 failed
-    pub async fn photo_to_proto(self, s3: &S3, quality_preference: PhotoQuality) -> Result<proto::Photo, S3Error> {
-        let photo_bytes = s3.get_photo_by_id(&self.id, quality_preference).await?;
+
+    pub async fn photo_to_proto(
+        self,
+        storage: &StorageEngine,
+        quality_preference: PhotoQuality
+    ) -> Result<proto::Photo, StorageEngineError> {
+        let photo_bytes = storage.get_photo_by_id(&self.id, quality_preference).await?;
         Ok(proto::Photo {
             id: self.id,
             album_id: self.album_id,

--- a/server/dal/src/database/photo.rs
+++ b/server/dal/src/database/photo.rs
@@ -42,9 +42,11 @@ impl<'a> Photo<'a> {
     pub async fn photo_to_proto(
         self,
         storage: &StorageEngine,
-        quality_preference: PhotoQuality
+        quality_preference: PhotoQuality,
     ) -> Result<proto::Photo, StorageEngineError> {
-        let photo_bytes = storage.get_photo_by_id(&self.id, quality_preference).await?;
+        let photo_bytes = storage
+            .get_photo_by_id(&self.id, quality_preference)
+            .await?;
         Ok(proto::Photo {
             id: self.id,
             album_id: self.album_id,

--- a/server/dal/src/lib.rs
+++ b/server/dal/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod database;
 pub mod s3;
+pub mod storage_engine;

--- a/server/dal/src/s3.rs
+++ b/server/dal/src/s3.rs
@@ -1,9 +1,9 @@
+use async_recursion::async_recursion;
 use aws_credential_types::Credentials;
 use aws_sdk_s3::error::{DeleteObjectError, GetObjectError, PutObjectError};
 use aws_sdk_s3::types::{ByteStream, SdkError};
 use aws_sdk_s3::{Client, Config, Region};
 use std::ops::Deref;
-use async_recursion::async_recursion;
 use thiserror::Error;
 
 pub mod aws_errors {
@@ -73,7 +73,10 @@ impl S3 {
     }
 
     #[async_recursion]
-    pub async fn get_photo_by_id<S: AsRef<str> + Send + Sync>(&self, photo_id: S) -> Result<Vec<u8>, S3Error> {
+    pub async fn get_photo_by_id<S: AsRef<str> + Send + Sync>(
+        &self,
+        photo_id: S,
+    ) -> Result<Vec<u8>, S3Error> {
         let photo = self
             .get_object()
             .bucket(&self.bucket_name)
@@ -90,7 +93,7 @@ impl S3 {
     pub async fn create_photo<S: AsRef<str>>(
         &self,
         photo_id: S,
-        bytes: Vec<u8>
+        bytes: Vec<u8>,
     ) -> Result<(), S3Error> {
         let byte_stream = ByteStream::from(bytes);
 

--- a/server/dal/src/s3.rs
+++ b/server/dal/src/s3.rs
@@ -1,10 +1,9 @@
 use aws_credential_types::Credentials;
-use aws_sdk_s3::error::{DeleteObjectError, GetObjectError, GetObjectErrorKind, PutObjectError};
+use aws_sdk_s3::error::{DeleteObjectError, GetObjectError, PutObjectError};
 use aws_sdk_s3::types::{ByteStream, SdkError};
 use aws_sdk_s3::{Client, Config, Region};
 use std::ops::Deref;
 use async_recursion::async_recursion;
-use strum_macros::Display;
 use thiserror::Error;
 
 pub mod aws_errors {
@@ -43,13 +42,6 @@ pub enum S3Error {
     ByteStream(#[from] aws_smithy_http::byte_stream::error::Error),
 }
 
-#[derive(Debug, Clone, PartialEq, Display)]
-pub enum PhotoQuality {
-    Original,
-    W400,
-    W1600,
-}
-
 pub struct S3Config {
     pub bucket_name: String,
     pub endpoint_url: String,
@@ -57,10 +49,6 @@ pub struct S3Config {
     pub access_key_id: String,
     pub secret_access_key: String,
     pub use_path_style: bool,
-}
-
-fn fmt_id_with_quality(id: &str, quality: PhotoQuality) -> String {
-    format!("{id}_{quality}")
 }
 
 impl S3 {
@@ -85,49 +73,30 @@ impl S3 {
     }
 
     #[async_recursion]
-    pub async fn get_photo_by_id<S: AsRef<str> + Send + Sync>(&self, photo_id: S, quality_preference: PhotoQuality) -> Result<Vec<u8>, S3Error> {
+    pub async fn get_photo_by_id<S: AsRef<str> + Send + Sync>(&self, photo_id: S) -> Result<Vec<u8>, S3Error> {
         let photo = self
             .get_object()
             .bucket(&self.bucket_name)
-            .key(&fmt_id_with_quality(photo_id.as_ref(), quality_preference.clone()))
+            .key(photo_id.as_ref())
             .send()
-            .await;
+            .await?;
 
-        match photo {
-            Ok(photo) => {
-                let bytes = photo.body.collect().await?;
-                let bytes = bytes.to_vec();
-                Ok(bytes)
-            },
-            Err(e) => {
-                match &e {
-                    SdkError::ServiceError(svc_e) => match svc_e.err().kind {
-                        GetObjectErrorKind::NoSuchKey(_) => {
-                            if quality_preference == PhotoQuality::Original {
-                                Err(e.into())
-                            } else {
-                                self.get_photo_by_id(photo_id.as_ref(), PhotoQuality::Original).await
-                            }
-                        },
-                        _ => Err(e.into())
-                    },
-                    _ => Err(e.into())
-                }
-            }
-        }
+        let bytes = photo.body.collect().await?;
+        let bytes = bytes.to_vec();
+
+        Ok(bytes)
     }
 
     pub async fn create_photo<S: AsRef<str>>(
         &self,
         photo_id: S,
-        bytes: Vec<u8>,
-        quality: PhotoQuality,
+        bytes: Vec<u8>
     ) -> Result<(), S3Error> {
         let byte_stream = ByteStream::from(bytes);
 
         self.put_object()
             .bucket(&self.bucket_name)
-            .key(&fmt_id_with_quality(photo_id.as_ref(), quality))
+            .key(photo_id.as_ref())
             .body(byte_stream)
             .send()
             .await?;
@@ -136,16 +105,9 @@ impl S3 {
     }
 
     pub async fn delete_photo<S: AsRef<str>>(&self, photo_id: S) -> Result<(), S3Error> {
-        self.delete_photo_with_quality(photo_id.as_ref(), PhotoQuality::Original).await?;
-        self.delete_photo_with_quality(photo_id.as_ref(), PhotoQuality::W1600).await?;
-        self.delete_photo_with_quality(photo_id.as_ref(), PhotoQuality::W400).await?;
-        Ok(())
-    }
-
-    async fn delete_photo_with_quality(&self, photo_id: &str, quality: PhotoQuality) -> Result<(), S3Error> {
         self.delete_object()
             .bucket(&self.bucket_name)
-            .key(&fmt_id_with_quality(photo_id, quality))
+            .key(photo_id.as_ref())
             .send()
             .await?;
         Ok(())

--- a/server/dal/src/storage_engine.rs
+++ b/server/dal/src/storage_engine.rs
@@ -1,0 +1,181 @@
+use crate::s3::{S3Config, S3Error, S3InitError, S3};
+use std::io;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use aws_sdk_s3::error::GetObjectErrorKind;
+use aws_smithy_http::result::SdkError;
+use strum_macros::Display;
+use thiserror::Error;
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::debug;
+
+#[derive(Debug, Error)]
+pub enum StorageEngineError {
+    /// S3 Error
+    #[error("{0}")]
+    S3(#[from] S3Error),
+    /// IO error
+    #[error("{0}")]
+    Io(#[from] io::Error),
+}
+
+/// Backend agnostic storage engine.
+#[derive(Debug, Clone)]
+pub struct StorageEngine(StorageEngineMode);
+
+#[derive(Debug, Clone)]
+enum StorageEngineMode {
+    S3(S3),
+    File(FileEngine),
+}
+
+impl StorageEngine {
+    /// Create a storage engine backed by S3.
+    ///
+    /// # Errors
+    ///
+    /// If initializing the S3 engine failed.
+    pub async fn new_s3(config: S3Config) -> Result<Self, S3InitError> {
+        let sdk = S3::new(config).await?;
+
+        Ok(Self(StorageEngineMode::S3(sdk)))
+    }
+
+    /// Create a storage engine backed by the local filesystem.
+    ///
+    /// # Errors
+    ///
+    /// If an IO error occurred.
+    pub async fn new_file(base_path: PathBuf) -> Result<Self, io::Error> {
+        if !base_path.exists() {
+            debug!("`file_base` does not exist, creating.");
+            tokio::fs::create_dir_all(&base_path).await?;
+        }
+
+        Ok(Self(StorageEngineMode::File(FileEngine { base_path })))
+    }
+
+    /// Retrieve a photo by ID.
+    ///
+    /// # Errors
+    ///
+    /// If the storage operation failed
+    pub async fn get_photo_by_id<S: AsRef<str>>(
+        &self,
+        photo_id: S,
+        quality_preference: PhotoQuality,
+    ) -> Result<Vec<u8>, StorageEngineError> {
+        let quality_id = fmt_id_with_quality(photo_id.as_ref(), &quality_preference);
+
+        match &self.0 {
+            StorageEngineMode::S3(s3) => {
+                match s3.get_photo_by_id(quality_id).await {
+                    Ok(photo) => Ok(photo),
+                    Err(S3Error::GetObject(e)) => {
+                        match &e {
+                            SdkError::ServiceError(svc_e) => match svc_e.err().kind {
+                                GetObjectErrorKind::NoSuchKey(_) => {
+                                    if quality_preference == PhotoQuality::Original {
+                                        Err(StorageEngineError::S3(S3Error::GetObject(e)))
+                                    } else {
+                                        Ok(s3.get_photo_by_id(photo_id.as_ref()).await?)
+                                    }
+                                },
+                                _ => Err(StorageEngineError::S3(S3Error::GetObject(e)))
+                            },
+                            _ => Err(StorageEngineError::S3(S3Error::GetObject(e)))
+                        }
+                    },
+                    Err(e) => Err(StorageEngineError::S3(e)),
+                }
+            },
+            StorageEngineMode::File(engine) => {
+                match engine.get_photo_by_id(quality_id).await {
+                    Ok(photo) => Ok(photo),
+                    Err(e) => match e.kind() {
+                        ErrorKind::NotFound => {
+                            if quality_preference == PhotoQuality::Original {
+                                Err(e.into())
+                            } else {
+                                Ok(engine.get_photo_by_id(photo_id.as_ref()).await?)
+                            }
+                        },
+                        _ => Err(e.into())
+                    }
+                }
+            },
+        }
+    }
+
+    /// Create a photo.
+    ///
+    /// # Errors
+    ///
+    /// If the storage operation failed
+    pub async fn create_photo<S: AsRef<str>>(&self, photo_id: S, bytes: Vec<u8>, quality: PhotoQuality) -> Result<(), StorageEngineError> {
+        let quality_id = fmt_id_with_quality(photo_id.as_ref(), &quality);
+        Ok(match &self.0 {
+            StorageEngineMode::S3(s3) => s3.create_photo(quality_id, bytes).await?,
+            StorageEngineMode::File(engine) => engine.create_photo(quality_id, bytes).await?,
+        })
+    }
+
+    /// Delete a photo by its ID.
+    ///
+    /// # Errors
+    ///
+    /// If the storage operation failed
+    pub async fn delete_photo<S: AsRef<str>>(&self, photo_id: S, quality: PhotoQuality) -> Result<(), StorageEngineError> {
+        let quality_id = fmt_id_with_quality(photo_id.as_ref(), &quality);
+        Ok(match &self.0 {
+            StorageEngineMode::S3(s3) => s3.delete_photo(quality_id).await?,
+            StorageEngineMode::File(engine) => engine.delete_photo(quality_id).await?,
+        })
+    }
+}
+
+/// Storage engine backed by the local filesystem
+#[derive(Debug, Clone)]
+struct FileEngine {
+    base_path: PathBuf,
+}
+
+impl FileEngine {
+    async fn get_photo_by_id<S: AsRef<str>>(&self, photo_id: S) -> Result<Vec<u8>, io::Error> {
+        let mut file = fs::File::open(self.base_path.join(photo_id.as_ref())).await?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).await?;
+
+        Ok(buf)
+    }
+
+    async fn create_photo<S: AsRef<str>>(
+        &self,
+        photo_id: S,
+        bytes: Vec<u8>,
+    ) -> Result<(), io::Error> {
+        let mut file = fs::File::create(self.base_path.join(photo_id.as_ref())).await?;
+        file.write_all(&bytes).await?;
+
+        Ok(())
+    }
+
+    async fn delete_photo<S: AsRef<str>>(&self, photo_id: S) -> Result<(), io::Error> {
+        let path = self.base_path.join(photo_id.as_ref());
+        fs::remove_file(&path).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+pub enum PhotoQuality {
+    Original,
+    W400,
+    W1600,
+}
+
+pub(crate) fn fmt_id_with_quality(id: &str, quality: &PhotoQuality) -> String {
+    format!("{id}_{quality}")
+}


### PR DESCRIPTION
This PR adds support for a local filesystem as a storage engine, rather than just S3.

This change should make it easier for other developers to run Chroma, as they don't need to run an S3 server.