### PR TITLE
Improve image pipeline

### DIFF
--- a/server/chroma/Cargo.toml
+++ b/server/chroma/Cargo.toml
@@ -27,6 +27,7 @@ tap = "1.0.1"
 webp = "0.2.5"
 img-parts = "0.3.0"
 time = "0.3.28"
+kamadak-exif = "0.5.5"
 
 [dev-dependencies]
 serde_json = "1.0.93"

--- a/server/chroma/src/routes/error.rs
+++ b/server/chroma/src/routes/error.rs
@@ -20,10 +20,14 @@ pub enum Error {
     Forbidden,
     #[error("Failed to parse timestamp")]
     ChronoParse(#[from] chrono::ParseError),
-    #[error("Failed to encode image to WebP")]
-    ImageEncoding,
     #[error("Other: {0}")]
     Other(StatusCode),
+    #[error("{0}")]
+    ImagePipeline(#[from] ImagePipelineError),
+    #[error("{0}")]
+    ImageEncoding(#[from] image::ImageError),
+    #[error("Failed to decode WebP image")]
+    WebpDecode,
 }
 
 impl ResponseError for Error {
@@ -36,8 +40,45 @@ impl ResponseError for Error {
             Self::Koala(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::ChronoParse(_) => StatusCode::BAD_GATEWAY,
-            Self::ImageEncoding => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::ImagePipeline(e) => e.status_code(),
+            Self::ImageEncoding(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::WebpDecode => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Other(s) => *s,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ImagePipelineError {
+    #[error("{0}")]
+    StringFromUtf8(#[from] std::string::FromUtf8Error),
+    #[error("{0}")]
+    DateTimeParse(#[from] chrono::format::ParseError),
+    #[error("EXIF metadata field '{0}' is of an invalid datatype")]
+    InvalidExifFieldType(&'static str),
+    #[error("Field '{0}' missing from EXIF metadata")]
+    MissingExifField(&'static str),
+    #[error("{0}")]
+    ExifParsing(#[from] exif::Error),
+    #[error("{0}")]
+    WebpEncoding(String),
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    ImgPartsDecode(#[from] img_parts::Error),
+}
+
+impl ImagePipelineError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::StringFromUtf8(_) => StatusCode::BAD_REQUEST,
+            Self::DateTimeParse(_) => StatusCode::BAD_REQUEST,
+            Self::InvalidExifFieldType(_) => StatusCode::BAD_REQUEST,
+            Self::MissingExifField(_) => StatusCode::BAD_REQUEST,
+            Self::ExifParsing(_) => StatusCode::BAD_REQUEST,
+            Self::WebpEncoding(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::ImgPartsDecode(_) => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/server/chroma/src/routes/v1/photo/get.rs
+++ b/server/chroma/src/routes/v1/photo/get.rs
@@ -92,8 +92,7 @@ fn reencode_dynamic_image(
     let mut cursor = Cursor::new(Vec::with_capacity(byte_count));
     image
         .write_to(&mut cursor, format)
-        .tap_err(|e| warn!("Failed to write image in format: {e}"))
-        .map_err(|_| Error::ImageEncoding)?;
+        .tap_err(|e| warn!("Failed to write image in format: {e}"))?;
 
     Ok(cursor.into_inner())
 }
@@ -103,7 +102,7 @@ fn decode_image(bytes: Vec<u8>) -> WebResult<DynamicImage> {
         Some(webp) => Ok(webp.to_image()),
         None => {
             warn!("Failed to decode WebP image");
-            Err(Error::ImageEncoding)
+            Err(Error::WebpDecode)
         }
     }
 }

--- a/server/dal/src/database/album.rs
+++ b/server/dal/src/database/album.rs
@@ -2,6 +2,8 @@ use crate::database::{Database, DatabaseError, DbResult, Photo, User};
 use rand::Rng;
 use sqlx::{FromRow, Type};
 use std::borrow::Cow;
+use std::fmt;
+use std::fmt::{Formatter, Pointer};
 use time::OffsetDateTime;
 
 pub struct Album<'a> {
@@ -16,7 +18,23 @@ pub struct Album<'a> {
     pub published_at: Option<i64>,
 }
 
-#[derive(Clone)]
+// Manually impl debug as to not print the `db` field
+impl fmt::Debug for Album<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Album")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("created_at", &self.created_at)
+            .field("created_by", &self.created_by)
+            .field("published_at", &self.published_at)
+            .field("published_by", &self.published_by)
+            .field("is_draft", &self.is_draft)
+            .field("cover_photo_id", &self.cover_photo_id)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum UserType {
     Koala(i32),
     ServiceToken(i32),

--- a/server/dal/src/database/photo.rs
+++ b/server/dal/src/database/photo.rs
@@ -2,7 +2,6 @@ use crate::database::{Album, Database, DbResult};
 use crate::storage_engine::{PhotoQuality, StorageEngine, StorageEngineError};
 use rand::Rng;
 use sqlx::FromRow;
-use time::OffsetDateTime;
 
 pub struct Photo<'a> {
     db: &'a Database,
@@ -64,9 +63,8 @@ impl<'a> Photo<'a> {
         format!("{}{random}", Self::ID_PREFIX)
     }
 
-    pub async fn create(db: &'a Database, album: &Album<'_>) -> DbResult<Photo<'a>> {
+    pub async fn create(db: &'a Database, album: &Album<'_>, created_at: i64) -> DbResult<Photo<'a>> {
         let id = Self::generate_id();
-        let created_at = OffsetDateTime::now_utc().unix_timestamp();
 
         sqlx::query("INSERT INTO photo_metadata (id, album_id, created_at) VALUES ($1, $2, $3)")
             .bind(&id)

--- a/server/dal/src/database/photo.rs
+++ b/server/dal/src/database/photo.rs
@@ -63,7 +63,11 @@ impl<'a> Photo<'a> {
         format!("{}{random}", Self::ID_PREFIX)
     }
 
-    pub async fn create(db: &'a Database, album: &Album<'_>, created_at: i64) -> DbResult<Photo<'a>> {
+    pub async fn create(
+        db: &'a Database,
+        album: &Album<'_>,
+        created_at: i64,
+    ) -> DbResult<Photo<'a>> {
         let id = Self::generate_id();
 
         sqlx::query("INSERT INTO photo_metadata (id, album_id, created_at) VALUES ($1, $2, $3)")

--- a/server/dal/src/storage_engine.rs
+++ b/server/dal/src/storage_engine.rs
@@ -189,6 +189,16 @@ pub enum PhotoQuality {
     W1600,
 }
 
+impl PhotoQuality {
+    pub fn width(&self) -> Option<u32> {
+        match self {
+            Self::Original => None,
+            Self::W400 => Some(400),
+            Self::W1600 => Some(1600),
+        }
+    }
+}
+
 pub(crate) fn fmt_id_with_quality(id: &str, quality: &PhotoQuality) -> String {
     format!("{id}_{quality}")
 }


### PR DESCRIPTION
This PR aims to improve the image pipeline, in multiple ways. Mainly:
- Speed up the request for the user.
- Try extracting the timestamp at which the image was created _by the user_, rather than uploaded

The speed ups are achieved by doing more work non-blocking (utilizing Tokio tasks) and parallel. E.g. uploading the original image to S3 is not done blocking anymore. Downside: No HTTP XXX is returned if the uploading fails. Should this be reverted?

Here's a quick overview of the current pipeline:
![chroma-image-pipeline](https://github.com/svsticky/chroma/assets/28569170/cadd80ef-d42a-4ed6-b622-e94aa72d56b0)

Blocks offset to the right do not block the main pipeline. 

Opinions? @SilasPeters @HugoPeters1024 